### PR TITLE
[fix #146] add line number after class name in log info.

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}:%L - %msg%n
             </pattern>
         </encoder>
     </appender>
@@ -37,7 +37,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            <pattern>%d{MM/dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}:%L - %msg%n
             </pattern>
         </encoder>
     </appender>


### PR DESCRIPTION
log info will be changed from 
'02/22 14:32:08.403 [pool-3-thread-1] INFO  com.iota.iri.network.Node  XXXXXXXXXXX' to
'02/22 14:32:08.403 [pool-3-thread-1] INFO  com.iota.iri.network.Node:492 XXXXXXXXX' .
where 492 is the line number of statement outputting to the log .