### PR TITLE
[fix #228] add neighbors to an IRI node by app service

### DIFF
--- a/scripts/iota_api/api.py
+++ b/scripts/iota_api/api.py
@@ -95,3 +95,10 @@ def getBalance(url, address, coin_type, account):
         "account": account
     }
     return API(cmd, url)
+
+def addNeighbors(url,uris):
+    cmd = {
+        "command": "addNeighbors",
+        "uris":uris
+    }
+    return API(cmd,url)

--- a/scripts/iota_api/app.py
+++ b/scripts/iota_api/app.py
@@ -233,6 +233,18 @@ def put_action():
     wasm.exec_action(ipfs_addr)
     return 'ok'
 
+@app.route('/add_neighbors', methods=['POST'])
+def add_neighbors():
+    req_json = request.get_json()
+    if req_json is None:
+        return 'error'
+    if not req_json.has_key(u'uris'):
+        print("[ERROR]Uris is needed.", file=sys.stderr)
+        return 'error'
+    uris = req_json[u'uris']
+    resp = cache.add_neighbors(uris)
+    return resp
+
 if __name__ == '__main__':
     get_cache()
     app.run(host=listen_address, port=listen_port)

--- a/scripts/iota_cache/iota_cache.py
+++ b/scripts/iota_cache/iota_cache.py
@@ -3,7 +3,7 @@ sys.path.append("..")
 import time
 from iota import Iota, Address, ProposedTransaction, Tag, Transaction, TryteString, TransactionTrytes, ProposedBundle, Nonce, BundleHash,TransactionHash, Fragment
 from six import binary_type, moves as compat, text_type
-from iota_api.api import attachToTangle, storeMessage, getBalance
+from iota_api.api import attachToTangle, storeMessage, getBalance, addNeighbors
 
 class IotaCache(object):
 
@@ -104,3 +104,6 @@ class IotaCache(object):
         result = self.cache_txn_in_tangle_sdk(ipfs_addr, tag+b"CONSUMED")
         return result
 
+    def add_neighbors(self, uris):
+        res = addNeighbors(self.uri,uris)
+        return res


### PR DESCRIPTION
add neighbors to an IRI node by app service

test:
curl -s -X POST http://127.0.0.1:5000/add_neighbors -H 'Content-Type: application/json' -H 'cache-control: no-cache' -d '{"command": "addNeighbors","uris":["udp://127.0.0.1:14600","tcp://127.0.0.1:14600"]}'
