### PR TITLE
[fix #231]  Add a method for delete and query neighbor nodes

### DIFF
--- a/scripts/iota_deploy/add_neighbors_batch.py
+++ b/scripts/iota_deploy/add_neighbors_batch.py
@@ -38,8 +38,8 @@ def check_ip_info(iplist,ippvts):
 
 def add_neighbors(source_ip,source_port,desc_ip,desc_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    content = ret.stdout.read().split('\n')[1]
+    ret = subprocess.check_output(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)])
+    content = ret.split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):
         add_flag = source_ip + '------>' + desc_ip + ':' + desc_port + '  false'
@@ -52,8 +52,8 @@ def add_neighbors(source_ip,source_port,desc_ip,desc_port):
 
 def remove_neighbors(source_ip,source_port,desc_ip,desc_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"removeNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    content = ret.stdout.read().split('\n')[1]
+    ret = subprocess.check_output(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"removeNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)])
+    content = ret.split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):
         remove_flag = source_ip + '----X-->' + desc_ip + ':' + desc_port + '  false'
@@ -66,8 +66,8 @@ def remove_neighbors(source_ip,source_port,desc_ip,desc_port):
 
 def get_neighbors(source_ip,source_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"getNeighbors"}' '''%(source_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    content = ret.stdout.read().split('\n')[1]
+    ret = subprocess.check_output(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"getNeighbors"}' '''%(source_port)])
+    content = ret.split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):
         get_info = source_ip+':'+source_port+u'邻居节点查询失败'

--- a/scripts/iota_deploy/add_neighbors_batch.py
+++ b/scripts/iota_deploy/add_neighbors_batch.py
@@ -38,7 +38,7 @@ def check_ip_info(iplist,ippvts):
 
 def add_neighbors(source_ip,source_port,desc_ip,desc_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     content = ret.stdout.read().split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):
@@ -52,7 +52,7 @@ def add_neighbors(source_ip,source_port,desc_ip,desc_port):
 
 def remove_neighbors(source_ip,source_port,desc_ip,desc_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"removeNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"removeNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     content = ret.stdout.read().split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):
@@ -66,7 +66,7 @@ def remove_neighbors(source_ip,source_port,desc_ip,desc_port):
 
 def get_neighbors(source_ip,source_port):
     ip_total = get_ip_list()
-    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"getNeighbors"}' '''%(source_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    ret = subprocess.Popen(["/usr/local/bin/pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"getNeighbors"}' '''%(source_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     content = ret.stdout.read().split('\n')[1]
     json_data  = json.loads(content)
     if json_data.has_key(u'error'):

--- a/scripts/iota_deploy/add_neighbors_batch.py
+++ b/scripts/iota_deploy/add_neighbors_batch.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-
 import re
 import subprocess
-# example usage: 172.21.0.30(src)  172.21.0.26(dest)  172.21.0.17(dest) 14600(port)
-#172.21.0.30 172.21.0.26 172.21.0.17
+import sys
+import json
+# example usage:python add_neighbors_batch.py  add  172.21.0.30:14700  172.21.0.26:14600  172.21.0.17:14600
 
 def check_ip(ip):
     p = re.compile('^((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)$')
@@ -13,7 +12,6 @@ def check_ip(ip):
         return True
     else:
         return False
-
 
 def get_ip_list():
     ipdict = {}
@@ -25,45 +23,100 @@ def get_ip_list():
         return ipdict
 
 def check_ip_info(iplist,ippvts):
-    a = []
-    if ippvts and len(iplist)>=3 :
+    check_flag = []
+    if ippvts and len(iplist)>=2 :
         ippvts = list(ippvts.keys())
-        for ipinfo in iplist[:-1]:
-            if check_ip(ipinfo) and ipinfo in ippvts:
-                a.append('True')
+        for ipinfo in iplist:
+            ipadress = ipinfo.split(':')[0]
+            if check_ip(ipadress) and ipadress in ippvts:
+                check_flag.append('True')
             else:
-                a.append('False')
+                check_flag.append('False')
     else :
-        a.append('False')
-    return a
+        check_flag.append('False')
+    return check_flag
 
-def add_neighbors(source_ip,desc_ip,port):
+def add_neighbors(source_ip,source_port,desc_ip,desc_port):
     ip_total = get_ip_list()
-    add_flag = []
-    for addip in desc_ip:
-        ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:14700 -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(addip,port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        if 'SUCCESS' in ret.stdout.readline().strip():
-            add_flag.append(source_ip + '------>' + addip + ':' + port + ' link success')
+    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"addNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    content = ret.stdout.read().split('\n')[1]
+    json_data  = json.loads(content)
+    if json_data.has_key(u'error'):
+        add_flag = source_ip + '------>' + desc_ip + ':' + desc_port + '  false'
+    else:
+        if json_data[u'addedNeighbors']>=1:
+            add_flag = source_ip + '------>' + desc_ip + ':' + desc_port + '  success'
         else:
-             add_flag.append(source_ip + '------>' + addip + ':' + port + ' link false')
+            add_flag = source_ip + '------>' + desc_ip + ':' + desc_port + '  already exist'
     return add_flag
 
-
-while True:
-    content = raw_input("please input your message:")
-    print(content,type(content))
-    iplist = str(content).split()
-    ippvts = get_ip_list()
-    check_flag = check_ip_info(iplist,ippvts)
-    if str(content) == 'q':
-        break
-    elif "False" in check_flag:
-        print("请检查主机列表是否为空或者输入IP格式不正确")
+def remove_neighbors(source_ip,source_port,desc_ip,desc_port):
+    ip_total = get_ip_list()
+    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"removeNeighbors", "uris": ["tcp://%s:%s"]}' '''%(source_port,desc_ip,desc_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    content = ret.stdout.read().split('\n')[1]
+    json_data  = json.loads(content)
+    if json_data.has_key(u'error'):
+        remove_flag = source_ip + '----X-->' + desc_ip + ':' + desc_port + '  false'
     else:
-        source_ip = iplist[0]
-        desc_ip = iplist[1:-1]
-        port = iplist[-1]
-        oret = add_neighbors(source_ip,desc_ip,port)
-        for link_info in oret:
-            print(link_info)
+        if json_data[u'removedNeighbors']>=1:
+            remove_flag = source_ip + '----X-->' + desc_ip + ':' + desc_port + '  success'
+        else:
+            remove_flag = source_ip + '------>' + desc_ip + ':' + desc_port + '  not exist'
+    return remove_flag
 
+def get_neighbors(source_ip,source_port):
+    ip_total = get_ip_list()
+    ret = subprocess.Popen(["pssh", "-i", "-H", "trust@"+ip_total[source_ip], "-x", "\"-oStrictHostKeyChecking=no\"",'''/usr/bin/curl -s http://localhost:%s -X POST -H 'Content-Type: application/json' -H  'X-IOTA-API-Version: 1' -d '{"command":"getNeighbors"}' '''%(source_port)],shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    content = ret.stdout.read().split('\n')[1]
+    json_data  = json.loads(content)
+    if json_data.has_key(u'error'):
+        get_info = source_ip+':'+source_port+u'邻居节点查询失败'
+    else:
+        ret_total = []
+        get_info = {}
+        for neighbors_ret in json_data[u'neighbors']:
+            address = neighbors_ret['address']
+            connectionType = neighbors_ret['connectionType']
+            ret_total.append(connectionType+'://'+address)
+        get_info[u'neighbors:'] = ret_total
+    return get_info
+
+def get_data_from_input(input_data,flag):
+    input_ip = input_data[1:]
+    ippvts = get_ip_list()
+    iplist = input_ip
+    check_flag = check_ip_info(iplist, ippvts)
+    if "False" in check_flag:
+        return  "请检查主机列表是否为空或者输入IP格式不正确"
+    else:
+        source_ip = input_ip[0].split(':')[0]
+        source_port = input_ip[0].split(':')[1]
+        ret_info = []
+        for neighbor_info in input_ip[1:]:
+            desc_ip = neighbor_info.split(':')[0]
+            desc_port = neighbor_info.split(':')[1]
+            if flag == 'add':
+                oret = add_neighbors(source_ip,source_port,desc_ip,desc_port)
+                ret_info.append(oret)
+            elif flag == 'remove':
+                oret = remove_neighbors(source_ip,source_port,desc_ip,desc_port)
+                ret_info.append(oret)
+        return ret_info
+
+if __name__=='__main__':
+    input_data = sys.argv
+    flag = input_data[1]
+    if flag in ['add','remove']:
+        try:
+            print(get_data_from_input(input_data[1:],flag))
+        except Exception as e:
+            print("%s失败"%flag)
+    elif flag == 'get':
+        ip = input_data[2].split(':')[0]
+        port = input_data[2].split(':')[1]
+        try:
+            print(get_neighbors(ip,port))
+        except Exception as e:
+            print("查询失败")
+    else:
+        print("输入格式有误")


### PR DESCRIPTION
Add a method for delete and query neighbor nodes：
使用方法：
add neighbors:
python add_neighbors_batch.py add 172.21.0.26:14700  172.21.0.17:13700 172.21.0.30:13700
在172.21.0.26上通过14700服务为其添加172.21.0.17，172.21.0.30两个邻居节点，通信端口为13700
remove neighbors:
python add_neighbors_batch.py remove 172.21.0.26:14700  172.21.0.17:13700 172.21.0.30:13700
在172.21.0.26上通过14700服务删除172.21.0.17，172.21.0.30通信端口为13700的两个邻居节点
get  neighbors:
python add_neighbors_batch.py get 172.21.0.26:14700
查询172.21.0.26:14700的邻居节点
