### PR TITLE
[fix #309] optimize network - add neighbor info to transactionRequester

### DIFF
--- a/src/main/java/com/iota/iri/validator/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/validator/TransactionValidator.java
@@ -171,7 +171,7 @@ public class TransactionValidator {
                         solid = false;
 
                         if (!transactionRequester.isTransactionRequested(hashPointer, milestone)) {
-                            transactionRequester.requestTransaction(hashPointer, milestone);
+                            transactionRequester.requestTransaction(hashPointer, null, milestone);
                             break;
                         }
                     } else {
@@ -294,7 +294,7 @@ public class TransactionValidator {
             genesis = provider.getGenesis();
         }
         if(approovee.getType() == PREFILLED_SLOT && (genesis == null || transactionViewModel.getHash() != genesis)) {
-            transactionRequester.requestTransaction(approovee.getHash(), false);
+            transactionRequester.requestTransaction(approovee.getHash(), null, false);
             return false;
         }
         if(approovee.getHash().equals(Hash.NULL_HASH)) {

--- a/src/main/java/com/iota/iri/validator/impl/LedgerValidatorImpl.java
+++ b/src/main/java/com/iota/iri/validator/impl/LedgerValidatorImpl.java
@@ -71,7 +71,7 @@ public class LedgerValidatorImpl implements LedgerValidator{
                 if (transactionViewModel.snapshotIndex() == 0 || transactionViewModel.snapshotIndex() > latestSnapshotIndex) {
                     numberOfAnalyzedTransactions++;
                     if (transactionViewModel.getType() == TransactionViewModel.PREFILLED_SLOT) {
-                        transactionRequester.requestTransaction(transactionViewModel.getHash(), milestone);
+                        transactionRequester.requestTransaction(transactionViewModel.getHash(), null, milestone);
                         return null;
 
                     } else {

--- a/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
@@ -79,7 +79,7 @@ public class TransactionRequesterTest {
         //fill tips list
         for (int i = 0; i < capacity * 2 ; i++) {
             Hash hash = TransactionViewModelTest.getRandomTransactionHash();
-            txReq.requestTransaction(hash,false);
+            txReq.requestTransaction(hash,null, false);
         }
         //check that limit wasn't breached
         assertEquals(capacity, txReq.numberOfTransactionsToRequest());
@@ -92,7 +92,7 @@ public class TransactionRequesterTest {
         //fill tips list
         for (int i = 0; i < capacity * 2 ; i++) {
             Hash hash = TransactionViewModelTest.getRandomTransactionHash();
-            txReq.requestTransaction(hash,true);
+            txReq.requestTransaction(hash,null, true);
         }
         //check that limit was surpassed
         assertEquals(capacity * 2, txReq.numberOfTransactionsToRequest());
@@ -105,7 +105,7 @@ public class TransactionRequesterTest {
         //fill tips list
         for (int i = 0; i < capacity * 4 ; i++) {
             Hash hash = TransactionViewModelTest.getRandomTransactionHash();
-            txReq.requestTransaction(hash, (i % 2 == 1));
+            txReq.requestTransaction(hash, null, (i % 2 == 1));
 
         }
         //check that limit wasn't breached


### PR DESCRIPTION
If we have neighbor info stored in transactionRequester, we can request the transaction from the specific Neighbor directly instead of broadcasting the request to every neighbor.

In this PR, we only add the mechanism, we will use it in the next PR.